### PR TITLE
Set file timestamps on downloaded photos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /env/
+/.cache/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Errors are printed to stderr.
 To see more options run with the --help flag.
 
 
+Running unit tests
+==================
+Run [`py.test`](http://pytest.org/).
+
+
 TODO
 ====
 * Mirror comments

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 120
+[pytest]
+python_files = flickrmirrorer.py


### PR DESCRIPTION
This change also adds unit tests and instructions on how to run them (just do
`py.test`).

The rationale for this change is that I wanted to copy photos and videos from
Flickr into Google Photo. And for Google Photo to know when different photos
have been taken, I'm guessing that it needs correctly timestamped files.

To be able to get `py.test` to run the tests, the main script had to have a
`.py` file extension, so I added that.

This change has been tested on 33GB of photos and videos.