### PR TITLE
Handle timestamp overflow errors gracefully

### DIFF
--- a/flickrmirrorer.py
+++ b/flickrmirrorer.py
@@ -669,9 +669,12 @@ class FlickrMirrorer(object):
         Args:
             timestamp (datetime.datetime)
         """
-        timestamp_since_epoch = time.mktime(timestamp.timetuple())
-        if timestamp_since_epoch != os.path.getmtime(filename):
-            os.utime(filename, (timestamp_since_epoch, timestamp_since_epoch))
+        try:
+            timestamp_since_epoch = time.mktime(timestamp.timetuple())
+            if timestamp_since_epoch != os.path.getmtime(filename):
+                os.utime(filename, (timestamp_since_epoch, timestamp_since_epoch))
+        except OverflowError:
+            self._progress('Error updating timestamp for: %s' % filename)
 
     def _write_json_if_different(self, filename, data):
         """Write the given data to the specified filename, but only if it's


### PR DESCRIPTION
If a Flickr photo has the "date taken" set to a pre-1970 date (i.e. before the Unix epoch), this results in an OverflowError from the call to `time.mktime`. Catching and reporting this error allows the mirroring process to continue instead of stopping whenever it encounters a photo like this.