### PR TITLE
Use "!=" instead of "is not" for numeric comparison.

### DIFF
--- a/flickrmirrorer.py
+++ b/flickrmirrorer.py
@@ -632,7 +632,7 @@ class FlickrMirrorer(object):
             # https://groups.yahoo.com/neo/groups/yws-flickr/conversations/topics/9610
             # https://groups.yahoo.com/neo/groups/yws-flickr/conversations/topics/9617
             head = requests.head(self._get_photo_url(photo), allow_redirects=True)
-            if head.status_code is not 200:
+            if head.status_code != 200:
                 raise VideoDownloadError(
                     'Manual download required: '
                     'https://www.flickr.com/video_download.gne?id=%s' % photo['id'])


### PR DESCRIPTION
In CPython 3.8 environment, using "is not 200" causes a SyntaxWarning,
as it's not designed for this and has fixed (issue an warning for now)
in 3.8:

SyntaxWarning: "is not" with a literal. Did you mean "!="?

Reference: https://bugs.python.org/issue34850